### PR TITLE
Fix for github ribbon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /*.iml
 /.idea
 /target
+/docs

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Forge Maven Skin
-Copyright 2013-2022 Bloomreach, Inc.
+Copyright 2013-2023 Bloomreach, Inc.
 
 Apache Maven - Fluido Skin
 Copyright 2011 The Apache Software Foundation

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2012-2022 Bloomreach, Inc.
+  Copyright 2012-2023 Bloomreach, Inc.
 
   Licensed under the Apache License, Version 2.0 (the  "License");
   you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   <name>Bloomreach Forge Maven Skin</name>
   <groupId>org.bloomreach.forge.mavenskin</groupId>
   <artifactId>forge-maven-skin</artifactId>
-  <version>3.1.2-SNAPSHOT</version>
+  <version>3.2.1-SNAPSHOT</version>
 
   <inceptionYear>2012</inceptionYear>
 
@@ -61,7 +61,7 @@
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 
@@ -69,7 +69,7 @@
     <repository>
       <id>hippo-maven2-forge</id>
       <name>Hippo Maven 2 Forge repository</name>
-      <url>http://maven.onehippo.com/maven2-forge/</url>
+      <url>https://maven.bloomreach.com/repository/maven2-forge/</url>
       <snapshots />
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,15 @@
     </repository>
   </repositories>
 
+  <properties>
+    <bootstrap.version>2.3.2</bootstrap.version>
+    <jquery.version>1.11.2</jquery.version>
+    <site-plugin.version>3.12.0</site-plugin.version>
+    <project-info-reports-plugin.version>3.3.0</project-info-reports-plugin.version>
+    <minify-maven-plugin.version>1.7.6</minify-maven-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+  </properties>
+
   <build>
     <resources>
       <!-- exclude css and js since will include the minified version -->
@@ -110,19 +119,24 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>${maven-resources-plugin.version}</version>
         <configuration>
           <encoding>UTF-8</encoding>
           <delimiters>
             <delimiter>@</delimiter>
           </delimiters>
           <useDefaultDelimiters>false</useDefaultDelimiters>
+          <nonFilteredFileExtensions>
+            <nonFilteredFileExtension>eot</nonFilteredFileExtension>
+            <nonFilteredFileExtension>ttf</nonFilteredFileExtension>
+            <nonFilteredFileExtension>woff</nonFilteredFileExtension>
+          </nonFilteredFileExtensions>
         </configuration>
       </plugin>
       <plugin>
         <groupId>com.samaxes.maven</groupId>
-        <artifactId>maven-minify-plugin</artifactId>
-        <version>1.3.5</version>
+        <artifactId>minify-maven-plugin</artifactId>
+        <version>${minify-maven-plugin.version}</version>
         <executions>
           <execution>
             <id>default-minify</id>
@@ -131,23 +145,25 @@
               <webappSourceDir>${basedir}/src/main/resources</webappSourceDir>
               <cssSourceDir>css</cssSourceDir>
               <cssSourceFiles>
-                <cssSourceFile>bootstrap-2.3.2.css</cssSourceFile>
-                <cssSourceFile>bootstrap-2.3.2-responsive.css</cssSourceFile>
+                <cssSourceFile>bootstrap-${bootstrap.version}.css</cssSourceFile>
+                <cssSourceFile>bootstrap-${bootstrap.version}-responsive.css</cssSourceFile>
                 <cssSourceFile>maven-base.css</cssSourceFile>
                 <cssSourceFile>maven-theme.css</cssSourceFile>
                 <cssSourceFile>prettify.css</cssSourceFile>
+                <cssSourceFile>gh-fork-ribbon.css</cssSourceFile>
                 <cssSourceFile>br-style.css</cssSourceFile>
               </cssSourceFiles>
               <cssFinalFile>forge-maven-skin-${project.version}.css</cssFinalFile>
               <jsSourceDir>js</jsSourceDir>
               <jsSourceFiles>
-                <jsSourceFile>jquery-1.11.2.js</jsSourceFile>
-                <jsSourceFile>bootstrap-2.3.2.js</jsSourceFile>
-                <jsSourceFile>fluido.js</jsSourceFile>
+                <jsSourceFile>jquery-${jquery.version}.js</jsSourceFile>
+                <jsSourceFile>bootstrap-${bootstrap.version}.js</jsSourceFile>
                 <jsSourceFile>prettify.js</jsSourceFile>
+                <jsSourceFile>fluido.js</jsSourceFile>
                 <jsSourceFile>main.js</jsSourceFile>
               </jsSourceFiles>
               <jsFinalFile>forge-maven-skin-${project.version}.js</jsFinalFile>
+              <jsEngine>CLOSURE</jsEngine>
             </configuration>
             <goals>
               <goal>minify</goal>
@@ -163,7 +179,7 @@
                 <cssSourceFile>shCore.css</cssSourceFile>
                 <cssSourceFile>shThemeDefault.css</cssSourceFile>
               </cssSourceFiles>
-              <cssFinalFile>forge-maven-skin-syntaxhighlighter-${project.version}.css</cssFinalFile>
+              <cssFinalFile>../forge-maven-skin-syntaxhighlighter-${project.version}.css</cssFinalFile>
               <jsSourceDir>js/syntaxhighlighter-3.0.83</jsSourceDir>
               <jsSourceFiles>
                 <jsSourceFile>shCore.js</jsSourceFile>
@@ -194,7 +210,7 @@
                 <jsSourceFile>shBrushVb.js</jsSourceFile>
                 <jsSourceFile>shBrushXml.js</jsSourceFile>
               </jsSourceFiles>
-              <jsFinalFile>forge-maven-skin-syntaxhighlighter-${project.version}.js</jsFinalFile>
+              <jsFinalFile>../forge-maven-skin-syntaxhighlighter-${project.version}.js</jsFinalFile>
             </configuration>
             <goals>
               <goal>minify</goal>
@@ -209,12 +225,12 @@
           <outputDirectory>docs</outputDirectory>
           <inputEncoding>UTF-8</inputEncoding>
         </configuration>
-        <version>3.6</version>
+        <version>${site-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.9</version>
+        <version>${project-info-reports-plugin.version}</version>
       </plugin>
     </plugins>
   </build>

--- a/src/main/resources/META-INF/maven/site-macros.vm
+++ b/src/main/resources/META-INF/maven/site-macros.vm
@@ -638,7 +638,21 @@
 <script type="text/javascript">asyncJs( 'https://cse.google.com/brand?form=search-form' )</script>
 #end
 ##
-##
+#macro ( forkMeOnGitHubHead )
+  ##
+  #set ( $ribbonColor = 'green' )
+  #set ( $definedRibbonColor = $decoration.custom.getChild( 'bloomreach' ).getChild( 'gitHub' ).getChild( 'ribbonColor' ) )
+  ##
+  #if ( $definedRibbonColor
+              && ( $definedRibbonColor.getValue().equalsIgnoreCase( "red" )
+              || $definedRibbonColor.getValue().equalsIgnoreCase( "green" )
+              || $definedRibbonColor.getValue().equalsIgnoreCase( "black" )
+              || $definedRibbonColor.getValue().equalsIgnoreCase( "orange" )
+              || $definedRibbonColor.getValue().equalsIgnoreCase( "gray" ) ) )
+          #set ( $ribbonColor = $definedRibbonColor.getValue().toLowerCase() )
+  #end
+  <style>.github-fork-ribbon:before { background-color: $ribbonColor; }</style>
+#end
 ##
 #macro ( forkMeOnGitHub )
   #if ( $decoration.custom.getChild( 'bloomreach' ).getChild( 'gitHub' )
@@ -646,34 +660,14 @@
   ##
     #set ( $gitHubProjectId = $decoration.custom.getChild( 'bloomreach' ).getChild( 'gitHub' ).getChild( 'projectId' ).getValue() )
   ##
-    #set ( $leftRibbon = { "red" : "forkme_left_red_aa0000.png", "green" : "forkme_left_green_007200.png", "black" : "forkme_left_darkblue_121621.png", "darkblue" : "forkme_left_darkblue_121621.png", "orange" : "forkme_left_orange_ff7600.png", "gray" : "forkme_left_gray_6d6d6d.png" } )
-    #set ( $rightRibbon = { "red" : "forkme_right_red_aa0000.png", "green" : "forkme_right_green_007200.png", "black" : "forkme_right_darkblue_121621.png", "darkblue" : "forkme_right_darkblue_121621.png", "orange" : "forkme_right_orange_ff7600.png", "gray" : "forkme_right_gray_6d6d6d.png" } )
-  ##
-    #set ( $ribbon = $rightRibbon )
     #set ( $ribbonOrientation = 'right' )
     #set ( $definedRibbonOrientation = $decoration.custom.getChild( 'bloomreach' ).getChild( 'gitHub' ).getChild( 'ribbonOrientation' ) )
     #if ( $definedRibbonOrientation && $definedRibbonOrientation.getValue().equalsIgnoreCase( "left" ) )
       #set ( $ribbonOrientation = 'left' )
-      #set ( $ribbon = $leftRibbon )
     #end
   ##
-    #set ( $ribbonColor = 'green' )
-    #set ( $definedRibbonColor = $decoration.custom.getChild( 'bloomreach' ).getChild( 'gitHub' ).getChild( 'ribbonColor' ) )
-  ##
-    #if ( $definedRibbonColor
-    && ( $definedRibbonColor.getValue().equalsIgnoreCase( "red" )
-    || $definedRibbonColor.getValue().equalsIgnoreCase( "green" )
-    || $definedRibbonColor.getValue().equalsIgnoreCase( "black" )
-    || $definedRibbonColor.getValue().equalsIgnoreCase( "orange" )
-    || $definedRibbonColor.getValue().equalsIgnoreCase( "gray" ) ) )
-      #set ( $ribbonColor = $definedRibbonColor.getValue().toLowerCase() )
-    #end
-  ##
-  <a href="https://github.com/$gitHubProjectId">
-    <img style="position: absolute; top: 0; $ribbonOrientation: 0; border: 0; z-index: 10000;"
-         src="https://s3.amazonaws.com/github/ribbons/$ribbon.get( $ribbonColor )"
-         alt="Fork me on GitHub">
-  </a>
+  <a target="_blank" class="github-fork-ribbon $ribbonOrientation" href="https://github.com/$gitHubProjectId"
+     data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
   #end
 #end
 ##

--- a/src/main/resources/META-INF/maven/site.vm
+++ b/src/main/resources/META-INF/maven/site.vm
@@ -63,6 +63,7 @@
 #**##if( $headContent )$headContent#end
 #**##googleAnalytics( $decoration.googleAnalyticsAccountId )
 #**##flattrHead()
+#**##forkMeOnGitHubHead()
 </head>
 #**##if ( $decoration.custom.getChild( 'bloomreach' )
 && $decoration.custom.getChild( 'bloomreach' ).getChild( 'topBarEnabled' )
@@ -232,7 +233,7 @@
 
   <div id="breadcrumbs">
     #set ($breadcrumbLink1 = 'xmdocumentation.bloomreach.com')
-    #set ($breadcrumbLink2 = 'developers.bloomreach.com')
+    #set ($breadcrumbLink2 = 'github.com/bloomreach-forge')
     #if ($decoration.custom.getChild('bloomreach'))
       #if ($decoration.custom.getChild('bloomreach').getChild('breadcrumbLink1') )
         #set ($breadcrumbLink1 = $decoration.custom.getChild('bloomreach').getChild('breadcrumbLink1').getValue())

--- a/src/main/resources/css/gh-fork-ribbon.css
+++ b/src/main/resources/css/gh-fork-ribbon.css
@@ -1,0 +1,124 @@
+/*!
+ * "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License
+ * https://github.com/simonwhitaker/github-fork-ribbon-css
+*/
+
+.github-fork-ribbon {
+  width: 12.1em;
+  height: 12.1em;
+  position: absolute;
+  overflow: hidden;
+  top: 0;
+  right: 0;
+  z-index: 9999;
+  pointer-events: none;
+  font-size: 13px;
+  text-decoration: none;
+  text-indent: -999999px;
+}
+
+.github-fork-ribbon.fixed {
+  position: fixed;
+}
+
+.github-fork-ribbon:hover, .github-fork-ribbon:active {
+  background-color: rgba(0, 0, 0, 0.0);
+}
+
+.github-fork-ribbon:before, .github-fork-ribbon:after {
+  /* The right and left classes determine the side we attach our banner to */
+  position: absolute;
+  display: block;
+  width: 15.38em;
+  height: 1.54em;
+
+  top: 3.23em;
+  right: -3.23em;
+
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.github-fork-ribbon:before {
+  content: "";
+
+  /* Add a bit of padding to give some substance outside the "stitching" */
+  padding: .38em 0;
+
+  /* Set the base colour */
+  background-color: #a00;
+
+  /* Set a gradient: transparent black at the top to almost-transparent black at the bottom */
+  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgba(0, 0, 0, 0.15)));
+  background-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -moz-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -ms-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -o-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+
+  /* Add a drop shadow */
+  -webkit-box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+  -moz-box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+  box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+
+  pointer-events: auto;
+}
+
+.github-fork-ribbon:after {
+  /* Set the text from the data-ribbon attribute */
+  content: attr(data-ribbon);
+
+  /* Set the text properties */
+  color: #fff;
+  font: 700 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 1.54em;
+  text-decoration: none;
+  text-shadow: 0 -.08em rgba(0, 0, 0, 0.5);
+  text-align: center;
+  text-indent: 0;
+
+  /* Set the layout properties */
+  padding: .15em 0;
+  margin: .15em 0;
+
+  /* Add "stitching" effect */
+  border-width: .08em 0;
+  border-style: dotted;
+  border-color: #fff;
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.github-fork-ribbon.left-top, .github-fork-ribbon.left-bottom {
+  right: auto;
+  left: 0;
+}
+
+.github-fork-ribbon.left-bottom, .github-fork-ribbon.right-bottom {
+  top: auto;
+  bottom: 0;
+}
+
+.github-fork-ribbon.left-top:before, .github-fork-ribbon.left-top:after, .github-fork-ribbon.left-bottom:before, .github-fork-ribbon.left-bottom:after {
+  right: auto;
+  left: -3.23em;
+}
+
+.github-fork-ribbon.left-bottom:before, .github-fork-ribbon.left-bottom:after, .github-fork-ribbon.right-bottom:before, .github-fork-ribbon.right-bottom:after {
+  top: auto;
+  bottom: 3.23em;
+}
+
+.github-fork-ribbon.left-top:before, .github-fork-ribbon.left-top:after, .github-fork-ribbon.right-bottom:before, .github-fork-ribbon.right-bottom:after {
+  -webkit-transform: rotate(-45deg);
+  -moz-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  -o-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,7 +19,7 @@
   <skin>
     <groupId>org.bloomreach.forge.mavenskin</groupId>
     <artifactId>forge-maven-skin</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
   </skin>
 
   <custom>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -26,8 +26,8 @@
         <subsection name="What is the Bloomreach Forge Maven Skin?">
             <p>
               The Bloomreach Forge Maven Skin is a Maven site skin based on
-              <a href="http://maven.apache.org/skins/maven-fluido-skin">Apache Maven Fluido Skin</a>.
-              That skin is based on <a href="http://twitter.github.com/bootstrap">Twitter's bootstrap</a> frontend framework.
+              <a href="https://maven.apache.org/skins/maven-fluido-skin">Apache Maven Fluido Skin</a>.
+              That skin is based on <a href="https://bootstrapdocs.com/v2.3.2/docs/">Twitter's bootstrap</a> frontend framework.
             </p>
         </subsection>
         <subsection name="Documentation">

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -20,6 +20,12 @@
   </properties>
   <body>
     <section name="Release Notes">
+      <subsection name="3.2.1">
+        <p class="smallinfo">Release Date: ??</p>
+        <ul>
+          <li>Updated references to Forge maven repositories to use https, and to use the bloomreach domain.</li>
+        </ul>
+      </subsection>
       <subsection name="3.2.0">
         <p class="smallinfo">Release Date: 22 September 2022</p>
         <ul>

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright 2012-2022 Bloomreach, Inc.
+  Copyright 2012-2023 Bloomreach, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,7 +23,8 @@
       <subsection name="3.2.1">
         <p class="smallinfo">Release Date: ??</p>
         <ul>
-          <li><a href="https://issues.onehippo.com/browse/FORGE-447">Fixed "Fork me on Github" ribbon.</a></li>
+          <li><a href="https://issues.onehippo.com/browse/FORGE-447">FORGE-447</a>
+            Fixed "Fork me on Github" ribbon.</li>
           <li>Updated references to Forge maven repositories to use https, and to use the bloomreach domain.</li>
         </ul>
       </subsection>
@@ -43,10 +44,10 @@
       <subsection name="3.1.0">
         <p class="smallinfo">Release Date: 15 March 2019</p>
         <ul>
-          <li><a href="https://issues.onehippo.com/browse/HIPFORGE-281">HIPFORGE-281</a>
+          <li><a href="https://issues.onehippo.com/browse/FORGE-281">FORGE-281</a>
             Set the URL behind the logo at bloomreach-forge.github.io, instead of to github.com/bloomreach-forge,
             and make it configurable in the descriptor element &lt;logoUrl&gt;, see the <a href="usage.html">usage page</a>.</li>
-          <li><a href="https://issues.onehippo.com/browse/HIPFORGE-281">HIPFORGE-281</a>
+          <li><a href="https://issues.onehippo.com/browse/FORGE-281">FORGE-281</a>
             Rename one of the two breadcrumb links from onehippo.org to documentatioon.bloomreach.com and make both
             links configurable in the descriptor elements &lt;breadcrumbLink1&gt; and &lt;breadcrumbLink2&gt;, see the <a href="usage.html">usage page</a>.</li>
         </ul>
@@ -59,7 +60,7 @@
       </subsection>
       <subsection name="3.0.0">
         <p class="smallinfo">Release Date: 1 November 2018</p>
-        <p><a href="https://issues.onehippo.com/browse/HIPFORGE-231">HIPFORGE-231</a> Rebranding from Hippo to Bloomreach</p>
+        <p><a href="https://issues.onehippo.com/browse/FORGE-231">FORGE-231</a> Rebranding from Hippo to Bloomreach</p>
         <ul>
           <li>Logo change, plus adding a site icon link.</li>
           <li>Rename Maven groupId from <code>org.onehippo.forge.mavenskin</code> to <code>org.bloomreach.forge.mavenskin</code>,

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -23,6 +23,7 @@
       <subsection name="3.2.1">
         <p class="smallinfo">Release Date: ??</p>
         <ul>
+          <li><a href="https://issues.onehippo.com/browse/FORGE-447">Fixed "Fork me on Github" ribbon.</a></li>
           <li>Updated references to Forge maven repositories to use https, and to use the bloomreach domain.</li>
         </ul>
       </subsection>

--- a/src/site/xdoc/typography.xml
+++ b/src/site/xdoc/typography.xml
@@ -27,8 +27,7 @@
           Use &lt;b&gt; for <b>bold text</b> or &lt;strong&gt; for <strong>strong text</strong>.<br/>
           Use &lt;tt&gt; or &lt;code&gt; for <tt>monospaced text</tt>.
         </p>
-        <p>Use a regular &lt;a&gt; for a <a href="https://www.bloomreach.com">http link</a> or a
-          <a href="https://developers.bloomreach.com">https link</a> or a <a href="mailto:info@bloomreach.com">mailto link</a>.</p>
+        <p>Use a regular &lt;a&gt; for a <a href="https://www.bloomreach.com">https link</a> or a <a href="mailto:info@bloomreach.com">mailto link</a>.</p>
         <p class="note">This is a notice, created by adding class <code>note</code> to an element.</p>
         <p class="smallinfo">This extra information, created by adding class <code>smallinfo</code> to an element,
         developed for the release dates below version headers in release notes.</p>

--- a/src/site/xdoc/typography.xml
+++ b/src/site/xdoc/typography.xml
@@ -27,7 +27,7 @@
           Use &lt;b&gt; for <b>bold text</b> or &lt;strong&gt; for <strong>strong text</strong>.<br/>
           Use &lt;tt&gt; or &lt;code&gt; for <tt>monospaced text</tt>.
         </p>
-        <p>Use a regular &lt;a&gt; for a <a href="http://www.bloomreach.com">http link</a> or a
+        <p>Use a regular &lt;a&gt; for a <a href="https://www.bloomreach.com">http link</a> or a
           <a href="https://developers.bloomreach.com">https link</a> or a <a href="mailto:info@bloomreach.com">mailto link</a>.</p>
         <p class="note">This is a notice, created by adding class <code>note</code> to an element.</p>
         <p class="smallinfo">This extra information, created by adding class <code>smallinfo</code> to an element,
@@ -42,11 +42,11 @@
   <repository>
     <id>hippo-forge</id>
     <name>Hippo Forge Maven 2 repository.</name>
-    <url>http://maven.onehippo.com/maven2-forge/</url>
+    <url>https://maven.bloomreach.com/repository/maven2-forge/</url>
   </repository>]]></source>
       <p>
         <b>&lt;source&gt;</b> element will be displayed in 'plain' mode by default
-        , using <a href="http://alexgorbatchev.com/SyntaxHighlighter/">SyntaxHighlighter</a> automatically.
+        , using <a href="https://github.com/syntaxhighlighter/syntaxhighlighter">SyntaxHighlighter</a> automatically.
       </p>
       <p>
         If you want to render the source in better syntax highlighting, then you can wrap the <b>&lt;source&gt;</b>
@@ -58,12 +58,12 @@
   <repository>
     <id>hippo-forge</id>
     <name>Hippo Forge Maven 2 repository.</name>
-    <url>http://maven.onehippo.com/maven2-forge/</url>
+    <url>https://maven.bloomreach.com/repository/maven2-forge/</url>
   </repository>]]></source>
       </div>
       <p>
         You can use 'plain', 'xml', 'java', 'javascript', 'groovy', 'html', 'shell' and more!
-        Please find more on how to use different brushes and options at <a href="http://alexgorbatchev.com/SyntaxHighlighter/">SyntaxHighlighter</a>.
+        Please find more on how to use different brushes and options at <a href="https://github.com/syntaxhighlighter/syntaxhighlighter">SyntaxHighlighter</a>.
       </p>
     </section>
     <section name="Alerts">

--- a/src/site/xdoc/usage.xml
+++ b/src/site/xdoc/usage.xml
@@ -70,7 +70,7 @@
       <!-- Configurable URL behind the Bloomreach logo, defaulting to https://bloomreach-forge.github.io -->
       <logoUrl>https://www.mysite.com</logoUrl>
 
-      <!-- Two configurable breadcrumb items, defaulting to 'documentation.bloomreach.com' and 'developers.bloomreach.com'
+      <!-- Two configurable breadcrumb items, defaulting to 'xmdocumentation.bloomreach.com' and 'github.com/bloomreach-forge'
            Protocol https:// will be prepended for the URL -->
       <breadcrumbLink1>www1.mysite.com</breadcrumbLink1>
       <breadcrumbLink2>www2.mysite.com</breadcrumbLink2>

--- a/src/site/xdoc/usage.xml
+++ b/src/site/xdoc/usage.xml
@@ -27,7 +27,7 @@
 <repository>
   <id>hippo-forge</id>
   <name>Hippo Forge maven 2 repository.</name>
-  <url>http://maven.onehippo.com/maven2-forge/</url>
+  <url>https://maven.bloomreach.com/repository/maven2-forge/</url>
 </repository>]]></source>
         </div>
       </subsection>
@@ -38,7 +38,7 @@
 <skin>
   <groupId>org.bloomreach.forge.mavenskin</groupId>
   <artifactId>forge-maven-skin</artifactId>
-  <version>3.2.0</version>
+  <version>3.2.1</version>
 </skin>]]></source>
             </div>
             <p>Note: before version 3.0.0, the <code>groupId</code> was <code>org.onehippo.forge.mavenskin</code>.</p>


### PR DESCRIPTION
https://issues.onehippo.com/browse/FORGE-447

1. Replaced github ribbon with CSS (taken from newer version of fluido skin).
2. Replaced breadcumb link to developers portal with a link to github bloomreach-forge.
3. Bumped dependencies and cleaned up copyright headers, broken http links and old maven repo links.